### PR TITLE
Fix reference error when trying to start a service; fixes #14

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/CityofSurrey/dockercloud#readme",
   "dependencies": {
+    "babel-polyfill": "^6.9.1",
     "request": "^2.71.0",
     "ws": "^1.1.0"
   },

--- a/src/dockercloud.js
+++ b/src/dockercloud.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import request from 'request'
 import WebSocket from 'ws'
 


### PR DESCRIPTION
When trying to start a service, an error
"**ReferenceError: regeneratorRuntime is not defined**" could be thrown,
traceback:

    ReferenceError: regeneratorRuntime is not defined
      at /src/node_modules/dockercloud/lib/dockercloud.js:424:39
      at /src/node_modules/dockercloud/lib/dockercloud.js:465:10
      at DockerCloud.startService (/src/node_modules/dockercloud/lib/dockercloud.js:422:14)
      at dc.services.findByName.then.t (repl:1:74)
      at process._tickDomainCallback (internal/process/next_tick.js:129:7)

This fixes the issue by following a suggestion to use **babel-polyfill**
from [this SO answer](http://stackoverflow.com/a/34195553/5624984).